### PR TITLE
Tokenize document on demand

### DIFF
--- a/src/keyvalue-document.ts
+++ b/src/keyvalue-document.ts
@@ -11,11 +11,15 @@
 
 import { CancellationToken, commands, DocumentFormattingEditProvider, FormattingOptions, OnTypeFormattingEditProvider, Position, ProviderResult, Range, TextDocument, TextEdit, workspace } from "vscode";
 import { KvTokensProviderBase } from "./keyvalue-parser/kv-token-provider-base";
-import { Token, TokenType } from "./keyvalue-parser/kv-tokenizer";
+import { Token, Tokenizer, TokenType } from "./keyvalue-parser/kv-tokenizer";
 
 const keyvalueDocuments: { file: string, document: KeyvalueDocument }[] = [];
+const tokenizer = new Tokenizer();
 
 export function getDocument(document: TextDocument): KeyvalueDocument | undefined {
+    if(!hasDocument(document)) {
+        tokenizeDocument(document);
+    }
     return keyvalueDocuments.find(d => d.file === document.uri.path)?.document;
 }
 
@@ -34,8 +38,13 @@ export function addDocument(document: TextDocument, tokens: Token[]): void {
     }
 }
 
-export function tokenizeDocument(document: TextDocument): Thenable<unknown> {
-    return commands.executeCommand("vscode.provideDocumentSemanticTokens", document.uri);
+export function tokenizeDocument(document: TextDocument): Token[] {
+    const text = document.getText();
+    tokenizer.tokenizeFile(text);
+    const tokens = tokenizer.tokens;
+
+    addDocument(document, tokens);
+    return tokens;
 }
 
 export class KeyvalueDocument {

--- a/src/keyvalue-parser/kv-token-provider-base.ts
+++ b/src/keyvalue-parser/kv-token-provider-base.ts
@@ -9,7 +9,7 @@
 // ==========================================================================
 
 import { CancellationToken, commands, Diagnostic, DiagnosticCollection, DiagnosticSeverity, DocumentSemanticTokensProvider, Event, ProviderResult, Range, SemanticTokens, SemanticTokensBuilder, SemanticTokensLegend, TextDocument } from "vscode";
-import { addDocument } from "../keyvalue-document";
+import { addDocument, tokenizeDocument } from "../keyvalue-document";
 import { isQuoted, stripQuotes } from "./kv-string-util";
 import { Token, Tokenizer, TokenType } from "./kv-tokenizer";
 
@@ -50,17 +50,9 @@ export abstract class KvTokensProviderBase implements DocumentSemanticTokensProv
         this.diagnostics = [];
         this.bracketStack = 0;
 
-        const text = document.getText();
-        this.tokenizer.tokenizeFile(text);
-        const tokens = this.tokenizer.tokens;
-
-        addDocument(document, tokens);
-
         const tokensBuilder = new SemanticTokensBuilder(this.legend);
 
-        commands.executeCommand("vscode.executeDocumentColorProvider");
-
-        return this.buildTokens(tokens, tokensBuilder, document);
+        return this.buildTokens(tokenizeDocument(document), tokensBuilder, document);
     }
 
     buildTokens(tokens: Token[], tokensBuilder: SemanticTokensBuilder, document: TextDocument) : SemanticTokens {


### PR DESCRIPTION
If the document hasn't been tokenized yet but is requested via `getDocument()`, tokenize it and return it