### PR TITLE
lights.rad syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
         "onLanguage:qc",
         "onLanguage:fgd",
         "onLanguage:vpc",
-        "onLanguage:cfg"
+        "onLanguage:cfg",
+        "onLanguage:rad"
     ],
     "contributes": {
         "snippets": [
@@ -163,6 +164,15 @@
                     ".qc",
                     ".mc"
                 ]
+            },
+            {
+                "id": "rad",
+                "aliases": [
+                    "Valve RAD File"
+                ],
+                "extensions": [
+                    ".rad"
+                ]
             }
         ],
         "grammars": [
@@ -200,6 +210,11 @@
                 "language": "qc",
                 "scopeName": "source.qc",
                 "path": "./syntaxes/qc.tmLanguage.json"
+            },
+            {
+                "language": "rad",
+                "scopeName": "source.rad",
+                "path": "./syntaxes/rad.tmLanguage.json"
             }
         ],
         "commands": [

--- a/samples/lights.rad
+++ b/samples/lights.rad
@@ -1,0 +1,18 @@
+lights/white001			250 240 205 100
+lights/white002			189 233 247 425
+lights/white003			232 246 190 350
+lights/white004			170 228 247 425
+ldr:lights/white005			234 235 220 375
+
+
+lights/white006			234 235 220 100 234 235 220 50
+
+forcetextureshadow props_bts/hanging_walkway_128a.mdl
+forcetextureshadow props_bts/hanging_walkway_128a_lod1.mdl
+forcetextureshadow props_bts/hanging_walkway_128b.mdl
+ldr:forcetextureshadow props_bts/hanging_walkway_128c.mdl
+hdr:forcetextureshadow props_bts/hanging_walkway_128d.mdl
+
+noshadow metal/metalgrate018b
+
+ldr:hdr: This can be used as a comment as the engine ignores this line, since you can't use ldr and hdr at the same time

--- a/syntaxes/rad.tmLanguage.json
+++ b/syntaxes/rad.tmLanguage.json
@@ -1,0 +1,51 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "RAD",
+	"scopeName": "source.rad",
+	"patterns": [
+        {
+            "include": "#prefixedProperties"
+        },
+        {
+            "include": "#textureLight"
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#prefixes"
+        }
+	],
+	"repository": {
+		"prefixedProperties": {
+            "match": "(forcetextureshadow|noshadow)\\s+([\\w/\\.\\\\]+)",
+            "captures": {
+                "1": {
+                    "name": "keyword.rad"
+                },
+                "2": {
+                    "name": "string.unquoted.rad"
+                }
+            }
+        },
+        "textureLight": {
+            "match": "([\\w/\\.\\\\]+)\\s+((\\d+\\s+){4,8})",
+            "captures": {
+                "1": {
+                    "name": "string.unquoted.rad"
+                },
+                "2": {
+                    "name": "constant.numeric.rad"
+                }
+            }
+        },
+        "prefixes": {
+            "match": "^(([hl]dr)(:)){1}",
+            "name": "keyword.control.rad"
+        },
+        "comments": {
+            "match": "(ldr:hdr:|hdr:ldr:).*",
+            "name": "comment.line.rad"
+        }
+	}
+}


### PR DESCRIPTION
Adds simple syntax highlighting for [Lights.rad](https://developer.valvesoftware.com/wiki/VRAD#Lights_files) files. Does not include semantic highlighting or color preview. Maybe some other time, this is good enough for now