### PR TITLE
Fix character after string being skipped in tokenization

### DIFF
--- a/src/kv-core/kv-tokenizer.test.ts
+++ b/src/kv-core/kv-tokenizer.test.ts
@@ -11,8 +11,8 @@ import * as tokenizer from "./kv-tokenizer";
 
 test("Tokenize Simple KV", () => {
     const tkn = new tokenizer.Tokenizer();
-    tkn.tokenizeFile(`
-        "File"
+    tkn.tokenizeFile(
+        `"File"
         {
             "Keyvalues" {
 
@@ -63,10 +63,15 @@ test("Tokenize Simple KV", () => {
 
     expect(tokens[0].value).toBe("\"File\"");
     expect(tokens[0].type).toBe(tokenizer.TokenType.Key);
+    expect(tokens[0].line).toBe(0);
     expect(tokens[1].value).toBe("{");
+    expect(tokens[1].line).toBe(1);
     expect(tokens[2].value).toBe("\"Keyvalues\"");
+    expect(tokens[2].line).toBe(2);
     expect(tokens[3].value).toBe("{");
+    expect(tokens[3].line).toBe(2);
     expect(tokens[4].value).toBe("// A comment");
+    expect(tokens[4].line).toBe(4);
     expect(tokens[5].value).toBe("\"Quoted Strings\"");
     expect(tokens[5].type).toBe(tokenizer.TokenType.Key);
     expect(tokens[6].value).toBe("\"a a\"");

--- a/src/kv-core/kv-tokenizer.ts
+++ b/src/kv-core/kv-tokenizer.ts
@@ -98,7 +98,8 @@ export class Tokenizer {
 
             this.addToken(tokenType, i, i + stringLength, stringContent, line);
             expectingKey = !expectingKey;
-            i += stringLength;
+            i += stringLength - 1; // Prevents skipping the next character after the string
+            continue;
         }
     }
 


### PR DESCRIPTION
The tokenizer used to skip the character following a string, which lead to newline characters being ignored, which caused tokens to have incorrect line numbers. Should fix a ton of strange bugs which popped up lately, since this wasn't properly tested.