### PR TITLE
Fix vmt color warnings when spaces are around brackets

### DIFF
--- a/src/language/lang-vmt.ts
+++ b/src/language/lang-vmt.ts
@@ -328,7 +328,7 @@ export class ShaderParamColorsProvider implements DocumentColorProvider {
 }
 
 function getColorMatches(colorString: string): { validFormat: boolean, outOfBounds: boolean, color: Color | null, matches: RegExpMatchArray | null }  {
-    const matches = colorString.match(/\[(0?\.\d+|1|0) (0?\.\d+|1|0) (0?\.\d+|1|0)\]/);
+    const matches = colorString.match(/ *\[ *(0?\.\d+|1|0) (0?\.\d+|1|0) (0?\.\d+|1|0) *\] */);
     if(!matches) return {
         validFormat: false,
         outOfBounds: false,


### PR DESCRIPTION
A color value like `"color" " [ 0.2 0.65 0.1 ] "` would get marked as invalid syntax before