### PR TITLE
Add support for <I> and <B> tags with no end partner in caption files

### DIFF
--- a/samples/resource/subtitles_english.txt
+++ b/samples/resource/subtitles_english.txt
@@ -6,7 +6,7 @@ lang
         "character.00" "<clr:255,125,240>Oh hi!"
         "character.01" "<clr:255,125,240>What do you mean you still write captions in notepad?"
         "character.02" "<clr:255,125,240>You know, I used to do the same, but ever since I found this vscode extension, I could never live without it."
-        "character.03" "<clr:255,125,240>It's just great, I'm telling you!"
+        "character.03" "<clr:255,125,240>It's just great, <I>I'm telling you!"
         "character.04" "<clr:255,125,240>It doesn't just color in basic keywords, no it actually formats markup."
         "character.05" "<clr:255,125,240>With this plugin, formatting tags like <B>bold<B> or <I>italic<I> actually receive their styles."
         "character.06" "<clr:55,250,240>But it doesn't end there. In fact, the color value of the clr tag shows you a preview of what this color looks like!<delay:5.0> Isn't that <clr:115,225,240>awesome?"

--- a/syntaxes/captions.tmLanguage.json
+++ b/syntaxes/captions.tmLanguage.json
@@ -95,20 +95,20 @@
             ]
         },
         "tagItalic": {
-            "begin": "\\<(?i)i(?-i)\\>",
-            "end": "\\<(?i)i(?-i)\\>",
+            "match": "(<[iI]>)([\\w '..,!?&\\[\\]\\(\\)]+)(<[iI]>)?",
             "captures": {
-                "0": { "name": "storage.modifier.fgd" }
+                "1": { "name": "storage.modifier.fgd" },
+                "3": { "name": "storage.modifier.fgd" }
             },
-            "contentName": "markup.italic.fgd"
+            "name": "markup.italic.fgd"
         },
         "tagBold": {
-            "begin": "\\<(?i)b(?-i)\\>",
-            "end": "\\<(?i)b(?-i)\\>",
+            "match": "(<[bB]>)([\\w '..,!?&\\[\\]\\(\\)]+)(<[bB]>)?",
             "captures": {
-                "0": { "name": "storage.modifier.fgd" }
+                "1": { "name": "storage.modifier.fgd" },
+                "3": { "name": "storage.modifier.fgd" }
             },
-            "contentName": "markup.bold.fgd"
+            "name": "markup.bold.fgd"
         },
         "tagSfx": {
             "match": "\\<(?i)sfx(?-i)\\>",


### PR DESCRIPTION
Previously, a <I> tag in a caption file, which was not closed off, would now highlight the entire file in italics. This fixes that and only allows highlight tags to span the entire line