### PR TITLE
Add fxc language syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,15 @@
                 "extensions": [
                     ".smd"
                 ]
+            },
+            {
+                "id": "fxc",
+                "aliases": [
+                    "FXC Shader"
+                ],
+                "extensions": [
+                    ".fxc"
+                ]
             }
         ],
         "grammars": [
@@ -258,6 +267,11 @@
                 "language": "smd",
                 "scopeName": "source.smd",
                 "path": "./syntaxes/smd.tmLanguage.json"
+            },
+            {
+                "language": "fxc",
+                "scopeName": "source.fxc",
+                "path": "./syntaxes/fxc.tmLanguage.json"
             }
         ],
         "commands": [

--- a/samples/shaders/Eyes_vs20.fxc
+++ b/samples/shaders/Eyes_vs20.fxc
@@ -1,0 +1,145 @@
+// From Source SDK 2013 https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/materialsystem/stdshaders/Eyes_vs20.fxc
+
+//======= Copyright © 1996-2006, Valve Corporation, All rights reserved. ======
+// $SHADER_SPECIFIC_CONST_0	 = eyeball origin			
+// $SHADER_SPECIFIC_CONST_1	 = eyeball up * 0.5			
+// $SHADER_SPECIFIC_CONST_2	 = iris projection U		
+// $SHADER_SPECIFIC_CONST_3	 = iris projection V		
+// $SHADER_SPECIFIC_CONST_4	 = glint projection U		
+// $SHADER_SPECIFIC_CONST_5	 = glint projection V		
+//=============================================================================
+
+//	STATIC: "INTRO"						"0..1"
+//  STATIC: "HALFLAMBERT"				"0..1"
+//  STATIC: "USE_STATIC_CONTROL_FLOW"	"0..1" [vs20]
+
+//	DYNAMIC: "COMPRESSED_VERTS"			"0..1"
+//	DYNAMIC: "SKINNING"					"0..1"
+//	DYNAMIC: "DOWATERFOG"				"0..1"
+//	DYNAMIC: "DYNAMIC_LIGHT"			"0..1"
+//	DYNAMIC: "STATIC_LIGHT"				"0..1"
+//  DYNAMIC: "MORPHING"					"0..1" [vs30]
+//  DYNAMIC: "NUM_LIGHTS"				"0..2" [vs20]
+
+// If using static control flow on Direct3D, we should use the NUM_LIGHTS=0 combo
+//  SKIP: $USE_STATIC_CONTROL_FLOW && ( $NUM_LIGHTS > 0 ) [vs20]
+
+#include "vortwarp_vs20_helper.h"
+
+static const int  g_bSkinning		= SKINNING ? true : false;
+static const int  g_FogType			= DOWATERFOG;
+static const bool g_bHalfLambert	= HALFLAMBERT ? true : false;
+
+const float3 cEyeOrigin						:  register( SHADER_SPECIFIC_CONST_0 );
+const float3 cHalfEyeballUp					:  register( SHADER_SPECIFIC_CONST_1 );
+const float4 cIrisProjectionU				:  register( SHADER_SPECIFIC_CONST_2 );
+const float4 cIrisProjectionV				:  register( SHADER_SPECIFIC_CONST_3 );
+const float4 cGlintProjectionU				:  register( SHADER_SPECIFIC_CONST_4 );
+const float4 cGlintProjectionV				:  register( SHADER_SPECIFIC_CONST_5 );
+#if INTRO
+const float4 const4							:  register( SHADER_SPECIFIC_CONST_6 );
+#define g_Time const4.w
+#define modelOrigin const4.xyz
+#endif
+
+#ifdef SHADER_MODEL_VS_3_0
+// NOTE: cMorphTargetTextureDim.xy = target dimensions,
+//		 cMorphTargetTextureDim.z = 4tuples/morph
+const float3 cMorphTargetTextureDim			: register( SHADER_SPECIFIC_CONST_7 );
+const float4 cMorphSubrect					: register( SHADER_SPECIFIC_CONST_8 );
+
+sampler2D morphSampler						: register( D3DVERTEXTEXTURESAMPLER0, s0 );
+#endif
+
+struct VS_INPUT
+{
+	float4 vPos					: POSITION;			// Position
+	float4 vBoneWeights			: BLENDWEIGHT;		// Skin weights
+	float4 vBoneIndices			: BLENDINDICES;		// Skin indices
+	float4 vTexCoord0			: TEXCOORD0;		// Base (sclera) texture coordinates
+
+	float3 vPosFlex				: POSITION1;		// Delta positions for flexing
+#ifdef SHADER_MODEL_VS_3_0
+	float vVertexID				: POSITION2;
+#endif
+};
+
+struct VS_OUTPUT
+{
+    float4 projPos				: POSITION;			// Projection-space position
+#if !defined( _X360 )
+	float  fog					: FOG;				// Fixed-function fog factor
+#endif
+	float2 baseTC				: TEXCOORD0;		// Base texture coordinate
+	float2 irisTC				: TEXCOORD1;		// Iris texture coordinates
+	float2 glintTC				: TEXCOORD2;		// Glint texture coordinates
+	float3 vColor				: TEXCOORD3;		// Vertex-lit color
+	
+	float4 worldPos_projPosZ	: TEXCOORD7;		// Necessary for pixel fog
+	
+};
+
+VS_OUTPUT main( const VS_INPUT v )
+{
+	VS_OUTPUT o;
+
+	bool bDynamicLight = DYNAMIC_LIGHT ? true : false;
+	bool bStaticLight = STATIC_LIGHT ? true : false;
+
+	float4 vPosition = v.vPos;
+	float3 dummy = v.vPos.xyz;		// dummy values that can't be optimized out
+
+#if !defined( SHADER_MODEL_VS_3_0 ) || !MORPHING
+	ApplyMorph( v.vPosFlex, vPosition.xyz );
+#else
+	ApplyMorph( morphSampler, cMorphTargetTextureDim, cMorphSubrect, v.vVertexID, dummy, vPosition.xyz );
+#endif
+
+	// Transform the position and dummy normal (not doing the dummy normal causes invariance issues with the flashlight!)
+	float3 worldNormal, worldPos;
+	SkinPositionAndNormal( 
+		g_bSkinning, 
+		vPosition, dummy,
+		v.vBoneWeights, v.vBoneIndices,
+		worldPos, worldNormal );
+
+#if INTRO
+	WorldSpaceVertexProcess( g_Time, modelOrigin, worldPos, dummy, dummy, dummy );
+#endif
+
+	// Transform into projection space
+	float4 vProjPos = mul( float4( worldPos, 1 ), cViewProj );
+	o.projPos = vProjPos;
+	vProjPos.z = dot( float4( worldPos, 1 ), cViewProjZ );
+	o.worldPos_projPosZ = float4( worldPos.xyz, vProjPos.z );
+
+#if !defined( _X360 )
+	// Set fixed-function fog factor
+	o.fog = CalcFog( worldPos, vProjPos, g_FogType );
+#endif
+
+	// Normal = (Pos - Eye origin) - just step on dummy normal created above
+	worldNormal = worldPos - cEyeOrigin;
+
+	// Normal -= 0.5f * (Normal dot Eye Up) * Eye Up
+	float normalDotUp = -dot( worldNormal, cHalfEyeballUp) * 0.5f;
+	worldNormal = normalize(normalDotUp * cHalfEyeballUp + worldNormal);
+
+	// Vertex lighting
+#if ( USE_STATIC_CONTROL_FLOW || defined ( SHADER_MODEL_VS_3_0 ) )
+	o.vColor = DoLighting( worldPos, worldNormal, float3(0.0f, 0.0f, 0.0f), bStaticLight, bDynamicLight, g_bHalfLambert );
+#else
+	o.vColor = DoLightingUnrolled( worldPos, worldNormal, float3(0.0f, 0.0f, 0.0f), bStaticLight, bDynamicLight, g_bHalfLambert, NUM_LIGHTS );
+#endif
+
+	// Texture 0 is the base texture
+	// Texture 1 is a planar projection used for the iris
+	// Texture 2 is a planar projection used for the glint
+	o.baseTC    = v.vTexCoord0;
+	o.irisTC.x  = dot( cIrisProjectionU,  float4(worldPos, 1) );
+	o.irisTC.y  = dot( cIrisProjectionV,  float4(worldPos, 1) );
+	o.glintTC.x = dot( cGlintProjectionU, float4(worldPos, 1) );
+	o.glintTC.y = dot( cGlintProjectionV, float4(worldPos, 1) );
+
+	return o;
+}

--- a/syntaxes/fxc.tmLanguage.json
+++ b/syntaxes/fxc.tmLanguage.json
@@ -1,0 +1,221 @@
+{
+	"information_for_contributors": [
+		"This file is an extended HLSL definition found here https://github.com/microsoft/vscode/blob/main/extensions/fxc/syntaxes/fxc.tmLanguage.json licensed"
+	],
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "FXC Shader",
+	"scopeName": "source.fxc",
+	"patterns": [
+		{
+			"name": "comment.line.block.fxc",
+			"begin": "/\\*",
+			"end": "\\*/"
+		},
+		{
+			"name": "comment.line.double-slash.fxc",
+			"begin": "//",
+			"end": "$",
+            "patterns": [
+                {
+                    "match": "(DYNAMIC|STATIC|SKIP): ",
+                    "name": "keyword.other.fxc"
+                }
+            ]
+		},
+		{
+			"name": "constant.numeric.decimal.fxc",
+			"match": "\\b[0-9]+\\.[0-9]*(F|f)?\\b"
+		},
+		{
+			"name": "constant.numeric.decimal.fxc",
+			"match": "(\\.([0-9]+)(F|f)?)\\b"
+		},
+		{
+			"name": "constant.numeric.decimal.fxc",
+			"match": "\\b([0-9]+(F|f)?)\\b"
+		},
+		{
+			"name": "constant.numeric.hex.fxc",
+			"match": "\\b(0(x|X)[0-9a-fA-F]+)\\b"
+		},
+		{
+			"name": "constant.language.fxc",
+			"match": "\\b(false|true)\\b"
+		},
+		{
+			"name": "keyword.preprocessor.fxc",
+			"match": "^\\s*#\\s*(define|elif|else|endif|ifdef|ifndef|if|undef|include|line|error|pragma)"
+		},
+		{
+			"name": "keyword.control.fxc",
+			"match": "\\b(break|case|continue|default|discard|do|else|for|if|return|switch|while)\\b"
+		},
+		{
+			"name": "keyword.control.fx.fxc",
+			"match": "\\b(compile)\\b"
+		},
+		{
+			"name": "keyword.typealias.fxc",
+			"match": "\\b(typedef)\\b"
+		},
+		{
+			"name": "storage.type.basic.fxc",
+			"match": "\\b(bool([1-4](x[1-4])?)?|double([1-4](x[1-4])?)?|dword|float([1-4](x[1-4])?)?|half([1-4](x[1-4])?)?|int([1-4](x[1-4])?)?|matrix|min10float([1-4](x[1-4])?)?|min12int([1-4](x[1-4])?)?|min16float([1-4](x[1-4])?)?|min16int([1-4](x[1-4])?)?|min16uint([1-4](x[1-4])?)?|unsigned|uint([1-4](x[1-4])?)?|vector|void)\\b"
+		},
+		{
+			"name": "support.function.fxc",
+			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)(?=[\\s]*\\()"
+		},
+		{
+			"name": "support.variable.semantic.fxc",
+			"match": "(?<=\\:\\s|\\:)(?i:BINORMAL[0-9]*|BLENDINDICES[0-9]*|BLENDWEIGHT[0-9]*|COLOR[0-9]*|NORMAL[0-9]*|POSITIONT|POSITION|PSIZE[0-9]*|TANGENT[0-9]*|TEXCOORD[0-9]*|FOG|TESSFACTOR[0-9]*|VFACE|VPOS|DEPTH[0-9]*)\\b"
+		},
+		{
+			"name": "support.variable.semantic.sm4.fxc",
+			"match": "(?<=\\:\\s|\\:)(?i:SV_ClipDistance[0-9]*|SV_CullDistance[0-9]*|SV_Coverage|SV_Depth|SV_DepthGreaterEqual[0-9]*|SV_DepthLessEqual[0-9]*|SV_InstanceID|SV_IsFrontFace|SV_Position|SV_RenderTargetArrayIndex|SV_SampleIndex|SV_StencilRef|SV_Target[0-7]?|SV_VertexID|SV_ViewportArrayIndex)\\b"
+		},
+		{
+			"name": "support.variable.semantic.sm5.fxc",
+			"match": "(?<=\\:\\s|\\:)(?i:SV_DispatchThreadID|SV_DomainLocation|SV_GroupID|SV_GroupIndex|SV_GroupThreadID|SV_GSInstanceID|SV_InsideTessFactor|SV_OutputControlPointID|SV_TessFactor)\\b"
+		},
+		{
+			"name": "support.variable.semantic.sm5_1.fxc",
+			"match": "(?<=\\:\\s|\\:)(?i:SV_InnerCoverage|SV_StencilRef)\\b"
+		},
+		{
+			"name": "storage.modifier.fxc",
+			"match": "\\b(column_major|const|export|extern|globallycoherent|groupshared|inline|inout|in|out|precise|row_major|shared|static|uniform|volatile)\\b"
+		},
+		{
+			"name": "storage.modifier.float.fxc",
+			"match": "\\b(snorm|unorm)\\b"
+		},
+		{
+			"name": "storage.modifier.postfix.fxc",
+			"match": "\\b(packoffset|register)\\b"
+		},
+		{
+			"name": "storage.modifier.interpolation.fxc",
+			"match": "\\b(centroid|linear|nointerpolation|noperspective|sample)\\b"
+		},
+		{
+			"name": "storage.modifier.geometryshader.fxc",
+			"match": "\\b(lineadj|line|point|triangle|triangleadj)\\b"
+		},
+		{
+			"name": "support.type.other.fxc",
+			"match": "\\b(string)\\b"
+		},
+		{
+			"name": "support.type.object.fxc",
+			"match": "\\b(AppendStructuredBuffer|Buffer|ByteAddressBuffer|ConstantBuffer|ConsumeStructuredBuffer|InputPatch|OutputPatch)\\b"
+		},
+		{
+			"name": "support.type.object.rasterizerordered.fxc",
+			"match": "\\b(RasterizerOrderedBuffer|RasterizerOrderedByteAddressBuffer|RasterizerOrderedStructuredBuffer|RasterizerOrderedTexture1D|RasterizerOrderedTexture1DArray|RasterizerOrderedTexture2D|RasterizerOrderedTexture2DArray|RasterizerOrderedTexture3D)\\b"
+		},
+		{
+			"name": "support.type.object.rw.fxc",
+			"match": "\\b(RWBuffer|RWByteAddressBuffer|RWStructuredBuffer|RWTexture1D|RWTexture1DArray|RWTexture2D|RWTexture2DArray|RWTexture3D)\\b"
+		},
+		{
+			"name": "support.type.object.geometryshader.fxc",
+			"match": "\\b(LineStream|PointStream|TriangleStream)\\b"
+		},
+		{
+			"name": "support.type.sampler.legacy.fxc",
+			"match": "\\b(sampler|sampler1D|sampler2D|sampler3D|samplerCUBE|sampler_state)\\b"
+		},
+		{
+			"name": "support.type.sampler.fxc",
+			"match": "\\b(SamplerState|SamplerComparisonState)\\b"
+		},
+		{
+			"name": "support.type.texture.legacy.fxc",
+			"match": "\\b(texture2D|textureCUBE)\\b"
+		},
+		{
+			"name": "support.type.texture.fxc",
+			"match": "\\b(Texture1D|Texture1DArray|Texture2D|Texture2DArray|Texture2DMS|Texture2DMSArray|Texture3D|TextureCube|TextureCubeArray)\\b"
+		},
+		{
+			"name": "storage.type.structured.fxc",
+			"match": "\\b(cbuffer|class|interface|namespace|struct|tbuffer)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.fxc",
+			"match": "\\b(FALSE|TRUE|NULL)\\b"
+		},
+		{
+			"name": "support.type.fx.fxc",
+			"match": "\\b(BlendState|DepthStencilState|RasterizerState)\\b"
+		},
+		{
+			"name": "storage.type.fx.technique.fxc",
+			"match": "\\b(technique|Technique|technique10|technique11|pass)\\b"
+		},
+		{
+			"name": "meta.object-literal.key.fx.blendstate.fxc",
+			"match": "\\b(AlphaToCoverageEnable|BlendEnable|SrcBlend|DestBlend|BlendOp|SrcBlendAlpha|DestBlendAlpha|BlendOpAlpha|RenderTargetWriteMask)\\b"
+		},
+		{
+			"name": "meta.object-literal.key.fx.depthstencilstate.fxc",
+			"match": "\\b(DepthEnable|DepthWriteMask|DepthFunc|StencilEnable|StencilReadMask|StencilWriteMask|FrontFaceStencilFail|FrontFaceStencilZFail|FrontFaceStencilPass|FrontFaceStencilFunc|BackFaceStencilFail|BackFaceStencilZFail|BackFaceStencilPass|BackFaceStencilFunc)\\b"
+		},
+		{
+			"name": "meta.object-literal.key.fx.rasterizerstate.fxc",
+			"match": "\\b(FillMode|CullMode|FrontCounterClockwise|DepthBias|DepthBiasClamp|SlopeScaleDepthBias|ZClipEnable|ScissorEnable|MultiSampleEnable|AntiAliasedLineEnable)\\b"
+		},
+		{
+			"name": "meta.object-literal.key.fx.samplerstate.fxc",
+			"match": "\\b(Filter|AddressU|AddressV|AddressW|MipLODBias|MaxAnisotropy|ComparisonFunc|BorderColor|MinLOD|MaxLOD)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.blend.fxc",
+			"match": "\\b(?i:ZERO|ONE|SRC_COLOR|INV_SRC_COLOR|SRC_ALPHA|INV_SRC_ALPHA|DEST_ALPHA|INV_DEST_ALPHA|DEST_COLOR|INV_DEST_COLOR|SRC_ALPHA_SAT|BLEND_FACTOR|INV_BLEND_FACTOR|SRC1_COLOR|INV_SRC1_COLOR|SRC1_ALPHA|INV_SRC1_ALPHA)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.blendop.fxc",
+			"match": "\\b(?i:ADD|SUBTRACT|REV_SUBTRACT|MIN|MAX)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.depthwritemask.fxc",
+			"match": "\\b(?i:ALL)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.comparisonfunc.fxc",
+			"match": "\\b(?i:NEVER|LESS|EQUAL|LESS_EQUAL|GREATER|NOT_EQUAL|GREATER_EQUAL|ALWAYS)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.stencilop.fxc",
+			"match": "\\b(?i:KEEP|REPLACE|INCR_SAT|DECR_SAT|INVERT|INCR|DECR)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.fillmode.fxc",
+			"match": "\\b(?i:WIREFRAME|SOLID)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.cullmode.fxc",
+			"match": "\\b(?i:NONE|FRONT|BACK)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.filter.fxc",
+			"match": "\\b(?i:MIN_MAG_MIP_POINT|MIN_MAG_POINT_MIP_LINEAR|MIN_POINT_MAG_LINEAR_MIP_POINT|MIN_POINT_MAG_MIP_LINEAR|MIN_LINEAR_MAG_MIP_POINT|MIN_LINEAR_MAG_POINT_MIP_LINEAR|MIN_MAG_LINEAR_MIP_POINT|MIN_MAG_MIP_LINEAR|ANISOTROPIC|COMPARISON_MIN_MAG_MIP_POINT|COMPARISON_MIN_MAG_POINT_MIP_LINEAR|COMPARISON_MIN_POINT_MAG_LINEAR_MIP_POINT|COMPARISON_MIN_POINT_MAG_MIP_LINEAR|COMPARISON_MIN_LINEAR_MAG_MIP_POINT|COMPARISON_MIN_LINEAR_MAG_POINT_MIP_LINEAR|COMPARISON_MIN_MAG_LINEAR_MIP_POINT|COMPARISON_MIN_MAG_MIP_LINEAR|COMPARISON_ANISOTROPIC|TEXT_1BIT)\\b"
+		},
+		{
+			"name": "support.constant.property-value.fx.textureaddressmode.fxc",
+			"match": "\\b(?i:WRAP|MIRROR|CLAMP|BORDER|MIRROR_ONCE)\\b"
+		},
+		{
+			"name": "string.quoted.double.fxc",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.fxc",
+					"match": "\\\\."
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Adds basic tmlanguage highlighting based off [hlsl from vscode](https://github.com/microsoft/vscode/blob/main/extensions/hlsl/syntaxes/hlsl.tmLanguage.json) enhanced to add highlighting for fxc comments

Added `Eyes_vs20.fxc` from [Source SDK 2013](https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/materialsystem/stdshaders/Eyes_vs20.fxc)