### PR TITLE
Keyvalue file auto detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "source-engine-support",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "source-engine-support",
-            "version": "0.9.0",
+            "version": "0.10.0",
             "license": "GPL-3.0+",
             "dependencies": {
                 "@sourcelib/captions": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
         "onLanguage:vpc",
         "onLanguage:cfg",
         "onLanguage:rad",
-        "onLanguage:soundscript"
+        "onLanguage:soundscript",
+        "onLanguage:plaintext"
     ],
     "contributes": {
         "snippets": [
@@ -192,7 +193,7 @@
                     "Source Soundscript"
                 ],
                 "filenamePatterns": [
-                    "game_sounds_*.txt",
+                    "game_sounds_example.txt",
                     "npc_sounds_*.txt",
                     "level_sounds_*.txt"
                 ]

--- a/package.json
+++ b/package.json
@@ -315,6 +315,31 @@
         "configuration": {
             "title": "Source Engine",
             "properties": {
+                "sourceEngine.kvAutoDetect.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable automatic detection of KeyValues files."
+                },
+                "sourceEngine.kvAutoDetect.onlyInSourceEngineWorkspaces": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable automatic detection of KeyValues files only in workspaces."
+                },
+                "sourceEngine.sourceEngineWorkspaces": {
+                    "type": "array",
+                    "default": [
+                        "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Portal 2",
+                        "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Half Life 2",
+                        "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Counter Strike Global Offensive",
+                        "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Team Fortress 2",
+                        "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Left 4 Dead 2",
+                        "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Alien Swarm"
+                    ],
+                    "description": "List of Source Engine workspaces. Some features are only enabled for files which are located in these workspaces.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "sourceEngine.performance.log": {
                     "type": "boolean",
                     "default": false,

--- a/src/KvFileDetection.ts
+++ b/src/KvFileDetection.ts
@@ -1,0 +1,130 @@
+import path from "path";
+import * as vscode from "vscode";
+import * as main from "./main";
+
+function isAutoDetectEnabled(): boolean {
+    return main.config.get<boolean>("kvAutoDetect.enabled", false);
+}
+
+function isAutoDetectEnabledOnlyInWorkspaces(): boolean {
+    return main.config.get<boolean>("kvAutoDetect.onlyInSourceEngineWorkspaces", true);
+}
+
+function getSourceEngineWorkspaces(): string[] {
+    return main.config.get<string[]>("sourceEngineWorkspaces", []);
+}
+
+const globalStateAutoDetectRecommended = "kvAutoDetect.recommended";
+function recommendAutoDetection(context: vscode.ExtensionContext): void {
+
+    const alreadyRecommended = context.globalState.get(globalStateAutoDetectRecommended, false);
+    if(alreadyRecommended) return;
+
+    vscode.window.showInformationMessage("Source Engine keyvalue files can be auto detected. Do you want to enable this feature?", "Yes", "No")
+        .then((value: string | undefined) => {
+            if(value === "Yes") {
+                main.config.update("kvAutoDetect.enabled", true, true);
+            }
+
+            context.globalState.update(globalStateAutoDetectRecommended, true);
+        });
+}
+
+export function init(context: vscode.ExtensionContext): void {
+    const onChange = vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor | undefined): void => {
+        main.debugOutput.appendLine(`Active editor changed to ${editor?.document.uri.fsPath}`);
+        if(editor === undefined) return;
+        detectKeyvalueFile(editor, context);
+    });
+    context.subscriptions.push(onChange);
+}
+
+function detectKeyvalueFile(editor: vscode.TextEditor, context: vscode.ExtensionContext): void {
+
+    if(!isAutoDetectEnabled()) {
+        main.debugOutput.appendLine("Auto detect is disabled. Not detecting kv file.");
+
+        recommendAutoDetection(context);
+        return;
+    }
+
+    main.debugOutput.appendLine("File has language id: " + editor.document.languageId);
+    if(editor.document.languageId === "plaintext") {
+        main.debugOutput.appendLine(`Potential kv file opened (${editor.document.uri.fsPath})`);
+
+        if(isPotentialKvFile(editor.document)) {
+            main.debugOutput.appendLine(`Changing document language of (${editor.document.uri.fsPath}) to keyvalue3`);
+            vscode.languages.setTextDocumentLanguage(editor.document, "keyvalue3");
+        } else {
+            main.debugOutput.appendLine(`Not changing document language of (${editor.document.uri.fsPath})`);
+        }
+
+    }
+}
+
+function isPotentialKvFile(document: vscode.TextDocument): boolean {
+    if(isAutoDetectEnabledOnlyInWorkspaces()) {
+
+        if(!isDocumentInSourceEngineWorkspace(document)) {
+            main.debugOutput.appendLine(`Auto detect is enabled only in source engine workspaces, but the document (${document.uri.fsPath}) is not in a source engine workspace.`);
+            return false;
+        }
+
+    }
+
+    const documentFileName = path.basename(document.uri.fsPath);
+
+    main.debugOutput.appendLine(`Auto detect is enabled. Checking if filename (${documentFileName}) is in list of common kv file names.`);
+    if(isFileNameCommonKvFile(documentFileName)) {
+        main.debugOutput.appendLine(`! File (${document.uri.fsPath}) is a potential kv file.`);
+        return true;
+    }
+
+    return false;
+}
+
+function isDocumentInSourceEngineWorkspace(document: vscode.TextDocument): boolean {
+    let fileUri: string = document.uri.fsPath;
+    let sourceEngineWorkspaces: string[] = getSourceEngineWorkspaces();
+
+    // Make paths lower case on windows
+    if(process.platform === "win32") {
+        fileUri = fileUri.toLowerCase();
+        sourceEngineWorkspaces = sourceEngineWorkspaces.map((workspace) => workspace.toLowerCase());
+    }
+
+    main.debugOutput.appendLine(`Checking if file (${fileUri}) is in any source engine workspace.`);
+
+    for(const workspace of sourceEngineWorkspaces) {
+        main.debugOutput.appendLine(`- Checking if file (${fileUri}) is in workspace (${workspace})`);
+        if(fileUri.startsWith(workspace)) {
+            main.debugOutput.appendLine(`! File (${fileUri}) is in workspace (${workspace})`);
+            return true;
+        }
+    }
+
+    main.debugOutput.appendLine(`! File (${fileUri}) is not in any source engine workspace.`);
+
+    return false;
+}
+
+const commonKvFileNames: RegExp[] = [
+    /gameinfo\.txt/i,
+    /subtitles_.+\.txt/i,
+    /captions_.+\.txt/i,
+    /basemodui_.+\.txt/i,
+    /game_sounds_.+\.txt/i,
+    /instructor_lessons\.txt/i,
+    /instructor_textures\.txt/i,
+    /npc_sounds_.+\.txt/i,
+    /level_sounds_.+\.txt/i,
+    /soundscapes_.+\.txt/i,
+    /surfaceproperties_.+\.txt/i,
+    /weapon_.+\.txt/i,
+    /vgui_screens\.txt/i,
+    /credits\.txt/i
+];
+
+function isFileNameCommonKvFile(fileName: string): boolean {
+    return commonKvFileNames.some((regex) => regex.test(fileName));
+}

--- a/src/language/LangKv.ts
+++ b/src/language/LangKv.ts
@@ -5,6 +5,7 @@
 // This is NOT a base for other formats!
 // ==========================================================================
 
+import * as shared from "./Shared";
 import * as vscode from "vscode";
 import { KvTokensProviderBase } from "./KvTokensProviderBase";
 //import { KvDocumentFormatter } from "./KvFormatter";
@@ -12,23 +13,10 @@ import { KvSemanticProcessor, KvSemanticProcessorParams } from "./KvSemanticProc
 import KvDocument from "./KvDocument";
 import { matrixRegExp } from "@sourcelib/vmt";
 
-export const filterKvSaved: vscode.DocumentFilter = {
-    language: "keyvalue3",
-    scheme: "file"
-};
-export const filterKvUnsaved: vscode.DocumentFilter = {
-    language: "keyvalue3",
-    scheme: "untitled"
-};
-export const filterSoundscriptSaved: vscode.DocumentFilter = {
-    language: "soundscript",
-    scheme: "file"
-};
-export const filterSoundscriptUnsaved: vscode.DocumentFilter = {
-    language: "soundscript",
-    scheme: "untitled"
-};
-export const selectorAll: ReadonlyArray<vscode.DocumentFilter> = [ filterKvSaved, filterKvUnsaved, filterSoundscriptSaved, filterSoundscriptUnsaved ];
+export const selectorAll: ReadonlyArray<vscode.DocumentFilter> = [ shared.filterKvSaved, 
+    shared.filterKvUnsaved, 
+    shared.filterSoundscriptSaved, 
+    shared.filterSoundscriptUnsaved ];
 
 export function init(context: vscode.ExtensionContext): void {
     const kvTokenProvider = new KeyvalueSemanticTokensProvider();

--- a/src/language/LangVmt.ts
+++ b/src/language/LangVmt.ts
@@ -3,6 +3,7 @@
 // Implementations of language utility providers for the vmt language.
 // ==========================================================================
 
+import * as shared from "./Shared";
 import vscode from "vscode";
 import KvDocument from "./KvDocument";
 //import { KvDocumentFormatter } from "./KvFormatter";
@@ -13,15 +14,8 @@ import { ShaderParamHoverProvider } from "./ShaderParamHoverProvider";
 import { ShaderParamColorsProvider } from "./ShaderParamColorsProvider";
 import { VmtSemanticTokenProvider } from "./VmtSemanticTokenProvider";
 
-export const filterVmtSaved: vscode.DocumentFilter = {
-    language: "vmt",
-    scheme: "file"
-};
-export const filterVmtUnsaved: vscode.DocumentFilter = {
-    language: "vmt",
-    scheme: "untitled"
-};
-export const selectorAll: ReadonlyArray<vscode.DocumentFilter> = [filterVmtSaved, filterVmtUnsaved];
+
+export const selectorAll: ReadonlyArray<vscode.DocumentFilter> = [shared.filterVmtSaved, shared.filterVmtUnsaved];
 
 export let shaderParams: ShaderParam[];
 export let internalTextures: string[];

--- a/src/language/Shared.ts
+++ b/src/language/Shared.ts
@@ -1,0 +1,35 @@
+import { DocumentFilter } from "vscode";
+
+export const languageIdKeyvalue = "keyvalue3";
+export const languageIdVmt = "vmt";
+export const languageIdSoundscript = "soundscript";
+export const languageIdCaptions = "captions";
+
+export function isAnyExtensionLanguageId(id: string): boolean {
+    return id === languageIdKeyvalue || id === languageIdVmt || id === languageIdSoundscript || id === languageIdCaptions;
+}
+
+export const filterKvSaved: DocumentFilter = {
+    language: languageIdKeyvalue,
+    scheme: "file"
+};
+export const filterKvUnsaved: DocumentFilter = {
+    language: languageIdKeyvalue,
+    scheme: "untitled"
+};
+export const filterSoundscriptSaved: DocumentFilter = {
+    language: languageIdSoundscript,
+    scheme: "file"
+};
+export const filterSoundscriptUnsaved: DocumentFilter = {
+    language: languageIdSoundscript,
+    scheme: "untitled"
+};
+export const filterVmtSaved: DocumentFilter = {
+    language: languageIdVmt,
+    scheme: "file"
+};
+export const filterVmtUnsaved: DocumentFilter = {
+    language: languageIdVmt,
+    scheme: "untitled"
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,12 @@ export function activate(context: vscode.ExtensionContext): void {
     updateConfig();
     const configChangeEvent = vscode.workspace.onDidChangeConfiguration(updateConfig);
     context.subscriptions.push(configChangeEvent);
+
+    vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor | undefined): void => {
+        if(editor === undefined) return;
+
+        
+    });
     
     keyvalue.init(context);
     vmt.init(context);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,27 +10,26 @@ import * as keyvalue from "./language/LangKv";
 import * as captionsCompile from "./compiler/captions-compile";
 import * as modelCompile from "./compiler/captions-compile";
 import * as performance from "./compiler/model-compile";
+import * as kvDetect from "./KvFileDetection";
 
 import * as packageJson from "../package.json";
 
 export let output: vscode.OutputChannel;
+export let debugOutput: vscode.OutputChannel;
 export let config: vscode.WorkspaceConfiguration;
 
 export function deactivate(): void {}
 export function activate(context: vscode.ExtensionContext): void {
     
     output = vscode.window.createOutputChannel("Source Engine Support");
-    context.subscriptions.push(output);
+    debugOutput = vscode.window.createOutputChannel("Source Engine Support Debug");
+    context.subscriptions.push(output, debugOutput);
     
     updateConfig();
     const configChangeEvent = vscode.workspace.onDidChangeConfiguration(updateConfig);
     context.subscriptions.push(configChangeEvent);
 
-    vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor | undefined): void => {
-        if(editor === undefined) return;
-
-        
-    });
+    kvDetect.init(context);
     
     keyvalue.init(context);
     vmt.init(context);


### PR DESCRIPTION
Many keyvalue files have .txt extensions which doesn't play nice with vscode. This feature allows the extension to auto detect whether a plaintext file is a potential keyvalue file and automatically changes the editor's language accordingly

- [x] Add source engine workspace setting to only auto detect files located in there
- [x] Recommend users to turn on auto detection when a plaintext file is opened (Only do this once)
- [x] Implement list of common source engine keyvalue file names
- [x] Automatically detect captions files and change the editor language accordingly